### PR TITLE
Add simple desktop notifier

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,3 +6,4 @@ Original author
 Additional authors
     Inhies (https://github.com/inhies/)
     Prurigro (https://github.com/prurigro/)
+    sercxanto (https://github.com/sercxanto/)

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ install:
 	install -D -m755 chkboot $(BIN)/chkboot
 	install -D -m755 chkboot-check $(BIN)/chkboot-check
 	install -D -m755 chkboot-profilealert.sh $(PROFILED)/chkboot-profilealert.sh
+	install -D -m755 chkboot-zenityalert $(BIN)/chkboot-zenityalert
 
 install-initcpio: install
 	install -D -m644 chkboot-initcpio $(LIB)/initcpio/install/chkboot

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ install -D -m644 chkboot/chkboot.conf /etc/default/chkboot.conf
 install -D -m755 chkboot/chkboot /usr/bin/chkboot
 install -D -m755 chkboot/chkboot-check /usr/bin/chkboot-check
 install -D -m755 chkboot/chkboot-profilealert.sh /etc/profile.d/chkboot-profilealert.sh
+install -D -m755 chkboot-zenityalert /usr/bin/chkboot-zenityalert
 ```
 
 To make `chkboot` run on startup on BSD-style init-based systems (e.g. Debian,
@@ -96,6 +97,10 @@ install -D -m644 chkboot/chkboot.service /usr/lib/systemd/system/chkboot.service
 install -D -m755 chkboot/chkboot-bootcheck /usr/lib/systemd/scripts/chkboot-bootcheck
 ```
 
+``chkboot-zenityalert`` notifies the desktop user about the change and can be
+included as startup script in the desktop environment. Its a simple adaption
+of Ju's initial idea.
+
 
 Credits
 -------
@@ -113,3 +118,4 @@ this repository, or at the [original URL] [2].
 Additional authors:
 Inhies (https://github.com/inhies/)
 Prurigro (https://github.com/prurigro/)
+sercxanto (https://github.com/sercxanto/)

--- a/chkboot-zenityalert
+++ b/chkboot-zenityalert
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# small script to check if files under /boot changed
+# Author: ju (ju at heisec dot de)
+# contributors: Georg Lutz <georg AT NORSPAM georglutz DOT de>
+#
+# License: GPLv2 or later
+
+source /etc/default/chkboot.conf
+
+chgfile=${CHKBOOT_DATA}/${CHANGES_ALERT}
+
+if [[ -s $chgfile ]] ; then 
+    cat $chgfile | zenity --title "ALERT: Boot changes" --text-info --width 500 --height 300
+    zenity --title "chkboot" --info --text="This notification will continue to appear until you either run chkboot again as root or restart your computer"
+fi
+


### PR DESCRIPTION
Use Ju's initial approach and show a info popup when the user logs in into his
desktop (``chkboot-zenityalert`` has to be referenced manually). This is not a
nice solution, "works for me", meaning I do not longer miss /boot changes.

Related to https://github.com/grazzolini/chkboot/issues/3 .

Change-UUID: 12c558e28de44690a0d175f5748335f2