### PR TITLE
Add pre and post transaction pacman hooks

### DIFF
--- a/80-chkboot-check.hook
+++ b/80-chkboot-check.hook
@@ -2,15 +2,8 @@
 Type = File
 Operation = Install
 Operation = Upgrade
-Target = usr/lib/modules/*/vmlinuz
-Target = usr/lib/initcpio/*
-
-[Trigger]
-Type = Package
-Operation = Install
-Operation = Upgrade
 Operation = Remove
-Target = systemd
+Target = boot/*
 
 [Action]
 Depends = chkboot

--- a/80-chkboot-check.hook
+++ b/80-chkboot-check.hook
@@ -1,0 +1,20 @@
+[Trigger]
+Type = File
+Operation = Install
+Operation = Upgrade
+Target = usr/lib/modules/*/vmlinuz
+Target = usr/lib/initcpio/*
+
+[Trigger]
+Type = Package
+Operation = Install
+Operation = Upgrade
+Operation = Remove
+Target = systemd
+
+[Action]
+Depends = chkboot
+Depends = coreutils
+Description = Comparing chkboot hashes...
+When = PreTransaction
+Exec = /usr/bin/sh -c 'if [ -s /var/lib/chkboot/boot-differences ]; then /usr/bin/echo "      ###WARNING### Previously modified boot files not acknowledged"; /usr/bin/echo "      ###WARNING### See chkboot log for details"; fi; /usr/lib/systemd/scripts/chkboot-bootcheck && if [ -s /var/lib/chkboot/boot-differences ]; then /usr/bin/echo "      ###WARNING### Modified boot files detected since last boot"; /usr/bin/echo "      ###WARNING### See chkboot log for details"; fi'

--- a/99-chkboot-update.hook
+++ b/99-chkboot-update.hook
@@ -1,0 +1,22 @@
+[Trigger]
+Type = File
+Operation = Install
+Operation = Upgrade
+Target = usr/lib/modules/*/vmlinuz
+Target = usr/lib/initcpio/*
+
+[Trigger]
+Type = Package
+Operation = Install
+Operation = Upgrade
+Operation = Remove
+Target = systemd
+Target = intel-ucode
+Target = amd-ucode
+
+[Action]
+Depends = chkboot
+Depends = coreutils
+Description = Updating chkboot hashes...
+When = PostTransaction
+Exec = /usr/bin/sh -c '/usr/bin/chkboot --update'

--- a/99-chkboot-update.hook
+++ b/99-chkboot-update.hook
@@ -2,17 +2,8 @@
 Type = File
 Operation = Install
 Operation = Upgrade
-Target = usr/lib/modules/*/vmlinuz
-Target = usr/lib/initcpio/*
-
-[Trigger]
-Type = Package
-Operation = Install
-Operation = Upgrade
 Operation = Remove
-Target = systemd
-Target = intel-ucode
-Target = amd-ucode
+Target = boot/*
 
 [Action]
 Depends = chkboot


### PR DESCRIPTION
These pacman hooks run whenever the system updates the boot images, systemd, or kernel microcode.

The pre-transaction hook detects: 1) modifications to the boot files which the user has been notified of but has not yet acknowledged, and 2) modifications to the boot files which have taken place since the last boot and the user is unaware of.

This verifies that no unauthorized modifications have taken place while the system has been in use.  It is necessary since the post-transaction hook assumes good files and updates all hashes accordingly.  A malicious bootkit that is aware of chkboot's existence on the system can, of course, simply update the hashes itself to bypass this verification.

The post-transaction hook assumes good files and updates all hashes accordingly.

These hooks require pull requests #9 and #10 to function properly

Additionally requires pull request #11 for EFI systems using a vfat boot partition