### PR TITLE
Detect initramfs rebuilds in pacman hooks

### DIFF
--- a/pacman-hooks/80-chkboot-check.hook
+++ b/pacman-hooks/80-chkboot-check.hook
@@ -3,6 +3,8 @@ Type = File
 Operation = Install
 Operation = Upgrade
 Operation = Remove
+Target = usr/lib/modules/*/vmlinuz
+Target = usr/lib/initcpio/*
 Target = boot/*
 
 [Action]

--- a/pacman-hooks/99-chkboot-update.hook
+++ b/pacman-hooks/99-chkboot-update.hook
@@ -3,6 +3,8 @@ Type = File
 Operation = Install
 Operation = Upgrade
 Operation = Remove
+Target = usr/lib/modules/*/vmlinuz
+Target = usr/lib/initcpio/*
 Target = boot/*
 
 [Action]


### PR DESCRIPTION
I know you said you wanted these hooks simplified, but further testing reveals that we still need to monitor these directories for changes.