### PR TITLE
profilealert fixes

### DIFF
--- a/notification/chkboot-profilealert.sh
+++ b/notification/chkboot-profilealert.sh
@@ -5,7 +5,7 @@
 #
 # license: GPLv2
 
-# only try to display chkboot changes if the 'proofile' alert style has been selected
+# only try to display chkboot changes if the 'profile' alert style has been selected
 if grep "^CHKBOOT_STYLES=.*profile" /etc/default/chkboot.conf >/dev/null ; then
     # run whatever issues exist then return the response
     chkboot-check

--- a/notification/chkboot-profilealert.sh
+++ b/notification/chkboot-profilealert.sh
@@ -7,7 +7,5 @@
 
 # only try to display chkboot changes if the 'profile' alert style has been selected
 if grep "^CHKBOOT_STYLES=.*profile" /etc/default/chkboot.conf >/dev/null ; then
-    # run whatever issues exist then return the response
     chkboot-check
-    return "$?"
 fi

--- a/notification/chkboot-profilealert.sh
+++ b/notification/chkboot-profilealert.sh
@@ -5,10 +5,8 @@
 #
 # license: GPLv2
 
-. /etc/default/chkboot.conf
-
 # only try to display chkboot changes if the 'proofile' alert style has been selected
-if [ ! $(echo "${CHKBOOT_STYLES}" | grep -c "profile") = 0 ]; then
+if grep "^CHKBOOT_STYLES=.*profile" /etc/default/chkboot.conf >/dev/null ; then
     # run whatever issues exist then return the response
     chkboot-check
     return "$?"

--- a/notification/chkboot-profilealert.sh
+++ b/notification/chkboot-profilealert.sh
@@ -5,7 +5,7 @@
 #
 # license: GPLv2
 
-source /etc/default/chkboot.conf
+. /etc/default/chkboot.conf
 
 # only try to display chkboot changes if the 'proofile' alert style has been selected
 if [ ! $(echo "${CHKBOOT_STYLES}" | grep -c "profile") = 0 ]; then

--- a/notification/chkboot-profilealert.sh
+++ b/notification/chkboot-profilealert.sh
@@ -1,6 +1,4 @@
-#!/usr/bin/env bash
-
-# chkboot-profilealert.sh: copy to /etc/profile.d/chkboot-profilealert.sh and change its permissions to executable
+# chkboot-profilealert.sh: copy to /etc/profile.d/chkboot-profilealert.sh
 #
 # author: ju (ju at heisec dot de)
 # contributors: inhies, prurigro


### PR DESCRIPTION
i installed chkboot (from debian unstable), and found a few issues with the profilealert script:

* it uses `source`, which is not available in all shells, and will cause errors
  (just set your login-shell to dash instead of bash and see yourself)
* using `#!/bin/bash` does NOT help, as profile scripts are sourced into whatever shell the user is using
* actually, `source`-ing the defaults will will load all it's settings into every shell on the system,
  just try `echo $BOOTDISK` after login