### PR TITLE
Update file exclusions

### DIFF
--- a/chkboot
+++ b/chkboot
@@ -67,8 +67,7 @@ fi
 dd if="$BOOTDISK" of="$DISKHEAD" bs=512 count=1 > /dev/null 2>&1
 
 pushd "$BOOTDIR" > /dev/null 2>&1
-    files=`find . -type f` # get file infos
-    files=`echo $files | sed "s/.\/grub\/grubenv//"` # remove files that should be skipped
+    files=`find . -type f | grep -ve ./grub/grubenv -ve ./loader/random-seed` # get file infos, exclude some files
 
     # generate hashes of each file
     for fname in $files; do


### PR DESCRIPTION
With systemd 243, systemd-boot generates a random-seed file at every boot.  This file needs to be excluded.
Use grep to simplify excluding multiple files.