### PR TITLE
Improve chkboot-desktopalert

### DIFF
--- a/notification/chkboot-desktopalert
+++ b/notification/chkboot-desktopalert
@@ -15,8 +15,8 @@ NOTIFICATION="This notification will continue to appear until you either run chk
 
 if [ -s $chgfile ]; then
     if [ -x $ZENITY ]; then
-        cat $chgfile | $ZENITY --title "ALERT: Boot changes" --text-info --width 550 --height 300
-        $ZENITY --title "chkboot" --info --text="$NOTIFICATION"
+        cat $chgfile | $ZENITY --title="ALERT: chkboot has detected boot changes" --window-icon=warning --text-info --width=550 --height=300
+        $ZENITY --title "chkboot" --info --text="$NOTIFICATION" --width=400
     elif [ -x $XMESSAGE ]; then
         cat $chgfile | $XMESSAGE -default okay -file -
         $XMESSAGE -default okay $NOTIFICATION


### PR DESCRIPTION
- Include chkboot in the zenity alert title to indicate the message's origin
- Add a warning icon
- Add width to the second notification to fix narrow, hard to read text