### PR TITLE
Man pages for chkboot, chkboot-check and chkboot-desktopalert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Generated manpages
+*.8

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,21 @@ DEFAULT = $(DESTDIR)/etc/default
 PROFILED = $(DESTDIR)/etc/profile.d
 LIB = $(DESTDIR)/usr/lib
 SHARE = $(DESTDIR)/usr/share
+MAN = $(SHARE)/man
 
-all:
+MANPAGES = man/chkboot.8 \
+	   man/chkboot-check.8 \
+	   man/chkboot-desktopalert.8
+
+all: man
+
+man: $(MANPAGES)
+
+$(MANPAGES): %.8: %.8.rst
+	rst2man $< > $@
+
+clean:
+	rm -vf man/*.8
 
 install:
 	install -D -m644 chkboot.conf $(DEFAULT)/chkboot.conf
@@ -24,4 +37,7 @@ install-systemd: install
 	install -D -m644 chkboot.service $(LIB)/systemd/system/chkboot.service
 	install -D -m755 chkboot-bootcheck $(LIB)/systemd/scripts/chkboot-bootcheck
 
-.PHONY: all install install-initcpio install-pacman install-systemd
+install-man: man
+	$(foreach manpage,$(MANPAGES),install -D -m644 $(manpage) $(MAN)/man8/$(notdir $(manpage));)
+
+.PHONY: all install install-initcpio install-pacman install-systemd man install-man clean

--- a/README.md
+++ b/README.md
@@ -55,6 +55,27 @@ make install-initcpio
 make install-systemd
 ```
 
+### To install man pages:
+
+Note: manpages are generated from ReStructuredText. They need rst2man from
+python-docutils:
+
+On Arch-linux:
+```
+pacman -S python-docutils
+```
+
+On Debian-like:
+```
+apt install python3-docutils
+```
+
+Install the manpages:
+
+```
+make install-man
+```
+
 Manual Installation 
 -------------------
 

--- a/man/chkboot-check.8.rst
+++ b/man/chkboot-check.8.rst
@@ -1,0 +1,33 @@
+=============
+chkboot-check
+=============
+
+------------------------------------------
+prints changes detected in your boot files
+------------------------------------------
+
+:Author: Ju <ju@heisec.de>, Giancarlo Razzolini <grazzolini@gmail.com>,
+         Chris Warner <inhies@gmail.com> and Kevin MacMartin <prurigro@gmail.com>
+:Date: 2019-04-17
+:Copyright: GPL-2
+:Version: 1.3
+:Manual section: 8
+:Manual group: System Manager's Manual
+
+SYNOPSIS
+========
+
+``chkboot-check``
+
+DESCRIPTION
+===========
+
+Print a detailed diff of added, changes and removed files, detected by
+``chkboot``.
+
+It will also print a warning when the MBR has been modified.
+
+SEE ALSO
+========
+
+* ``man chkboot`` and ``man chkboot-desktopalert``

--- a/man/chkboot-desktopalert.8.rst
+++ b/man/chkboot-desktopalert.8.rst
@@ -1,0 +1,35 @@
+====================
+chkboot-desktopalert
+====================
+
+------------------------------------------
+notify changes detected in your boot files
+------------------------------------------
+
+:Author: Ju <ju@heisec.de>, Giancarlo Razzolini <grazzolini@gmail.com>,
+         Chris Warner <inhies@gmail.com> and Kevin MacMartin <prurigro@gmail.com>
+:Date: 2019-04-17
+:Copyright: GPL-2
+:Version: 1.3
+:Manual section: 8
+:Manual group: System Manager's Manual
+
+SYNOPSIS
+========
+
+``chkboot-desktopalert``
+
+DESCRIPTION
+===========
+
+Display a notification with a detailed diff of added, changes and removed files,
+detected by ``chkboot``.
+
+It will also display a notification when the MBR has been modified.
+
+**You will need to add this program to your desktop environment's autostart.**
+
+SEE ALSO
+========
+
+* ``man chkboot`` and ``man chkboot-check``

--- a/man/chkboot.8.rst
+++ b/man/chkboot.8.rst
@@ -1,0 +1,61 @@
+=======
+chkboot
+=======
+
+---------------------------------------------------------------
+checks for unwanted modification on unencrypted /boot partition
+---------------------------------------------------------------
+
+:Author: Ju <ju@heisec.de>, Giancarlo Razzolini <grazzolini@gmail.com>,
+         Chris Warner <inhies@gmail.com> and Kevin MacMartin <prurigro@gmail.com>
+:Date: 2019-04-17
+:Copyright: GPL-2
+:Version: 1.3
+:Manual section: 8
+:Manual group: System Manager's Manual
+
+SYNOPSIS
+========
+
+``chkboot`` [OPTIONS]
+
+DESCRIPTION
+===========
+
+Checks for any modification to your boot files since last run.
+
+--update, -u            Mark changes as valid. Next run of ``chkboot`` will not
+                        warn about differences.
+--help, -h              Show this help message and exit.
+
+
+``chkboot`` runs at system startup to check for boot files modifications. User
+will be warn upon login if any are found.
+
+Kernel upgrade are automatically marked as valid.
+
+Configurations, such as boot partition, can be edited in:
+
+  ``/etc/default/chkboot``
+
+EXAMPLES
+========
+
+Acknowledge a detected changed after ``chkboot`` have displayed a warning:
+
+  ``chkboot``
+
+Clear valid modifications made by users:
+
+  ``chkboot -u``
+
+SEE ALSO
+========
+
+* ``man chkboot-check`` and ``man chkboot-desktopalert``
+
+BUGS
+====
+
+* GPT partitions are not supported. As chkboot will continue to work, it **will
+  not report changes in GPT headers** (only protective MBR).


### PR DESCRIPTION
Man pages for binaries accessible to users.

Man pages are written in ReStructuredText and converted to man format using `rst2man`.
This adds a new build dependency: `python-docutils`.

Can be built with:

```
make
```

Can be installed with:

```
make install-man
```

Other rules are not impacted and does not need the extra dependency.