### PR TITLE
hook for clearing modifications made by apt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 BIN = $(DESTDIR)/usr/bin
+ETC = $(DESTDIR)/etc
 DEFAULT = $(DESTDIR)/etc/default
 PROFILED = $(DESTDIR)/etc/profile.d
 LIB = $(DESTDIR)/usr/lib
@@ -20,8 +21,12 @@ install-pacman: install
 	install -D -m644 pacman-hooks/80-chkboot-check.hook $(SHARE)/libalpm/hooks/80-chkboot-check.hook
 	install -D -m644 pacman-hooks/99-chkboot-update.hook $(SHARE)/libalpm/hooks/99-chkboot-update.hook
 
+install-apt: install
+	install -D -m644 apt-hooks/05chkboot $(ETC)/apt/apt.conf.d/05chkboot
+	install -D -m755 apt-hooks/chkboot-update $(LIB)/chkboot/chkboot-update
+
 install-systemd: install
 	install -D -m644 chkboot.service $(LIB)/systemd/system/chkboot.service
 	install -D -m755 chkboot-bootcheck $(LIB)/systemd/scripts/chkboot-bootcheck
 
-.PHONY: all install install-initcpio install-pacman install-systemd
+.PHONY: all install install-initcpio install-pacman install-systemd install-apt

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ make install-initcpio
 make install-systemd
 ```
 
+### To install apt components:
+
+```
+make install-apt
+```
+
 Manual Installation 
 -------------------
 

--- a/apt-hooks/05chkboot
+++ b/apt-hooks/05chkboot
@@ -1,0 +1,1 @@
+DPkg::Post-Invoke { "if [ -x /usr/lib/chkboot/chkboot-update ]; then /usr/lib/chkboot/chkboot-update; fi"; };

--- a/apt-hooks/README.md
+++ b/apt-hooks/README.md
@@ -1,0 +1,29 @@
+# Apt Hooks for chkboot
+
+Hooks required to clear any modification made to /boot by apt.
+
+## How it works?
+
+On first install, chkboot Debian package take the following actions:
+  - register a trigger on /boot and initramfs update (stored in
+    `/var/lib/dpkg/triggers/`)
+  - install a function to create a flag file on trigger activation in
+    `/var/lib/dpkg/info/chkboot.postinst`
+  - install an apt hook in `/etc/apt/apt.conf.d/05chkboot` to run the update
+    script
+  - install an update script in `/usr/lib/chkboot/chkboot-update`
+
+Then, on trigger activation:
+  - flag file is created in `/var/lib/chkboot/needs-update`
+  - apt hook calls the update script
+  - update script clear modifications
+
+Note: The hook and update script are actually called at every apt invocation.
+Clearing the modification is only done if the flag file exists, from when the
+trigger is activated.
+
+## Files
+
+The update script and the apt hook are installed alongside chkboot. The trigger
+and the function to create the flag files are located in the Debian packaging
+files.

--- a/apt-hooks/chkboot-update
+++ b/apt-hooks/chkboot-update
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Post apt hook that clear valid modification with chkboot -u
+# Author: Baptiste BEAUPLAT <lynode@cilg.org>
+# license: GPLv2
+
+TRIGGER="/var/lib/chkboot/needs-update"
+
+# Only run if needed
+[[ -f "${TRIGGER}" ]] || exit 0
+rm -f "${TRIGGER}"
+
+echo "Updating chkboot hashes of your boot files..."
+
+# TEST TO SEE IF BOOT FILES WERE MODIFIED WITHOUT THE USER'S ACKNOWLEDGEMENT (BY
+# RUNNING 'chkboot') AND ALERT THEM IF IT HAS BEEN
+chkboot-check
+if [ "$?" = 1 ]; then
+    echo -e "\n### WARNING: Previously modified files were not acknowledged ###"
+    echo "### Check the issues log at ${CHANGES_LOG} for details ###"
+fi
+
+# RUN CHKBOOT TO UPDATE THE HASHES WITHOUT CREATING THE ALERT FILE
+chkboot -u
+sync


### PR DESCRIPTION
Clear modification on /boot make by apt.

The process is documented in `apt-hooks/README.md`.