### PR TITLE
Use more appropriate installation path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SHARE = $(DESTDIR)/usr/share
 all:
 
 install:
-	install -D -m644 chkboot.conf $(DEFAULT)/chkboot.conf
+	install -D -m644 chkboot.conf $(DEFAULT)/chkboot
 	install -D -m755 chkboot $(BIN)/chkboot
 	install -D -m755 chkboot-check $(BIN)/chkboot-check
 	install -D -m755 notification/chkboot-profilealert.sh $(PROFILED)/chkboot-profilealert.sh

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ BIN = $(DESTDIR)/usr/bin
 DEFAULT = $(DESTDIR)/etc/default
 PROFILED = $(DESTDIR)/etc/profile.d
 LIB = $(DESTDIR)/usr/lib
+LIBEXEC = $(DESTDIR)/usr/libexec
 SHARE = $(DESTDIR)/usr/share
 
 all:
@@ -12,6 +13,7 @@ install:
 	install -D -m755 chkboot-check $(BIN)/chkboot-check
 	install -D -m755 notification/chkboot-profilealert.sh $(PROFILED)/chkboot-profilealert.sh
 	install -D -m755 notification/chkboot-desktopalert $(BIN)/chkboot-desktopalert
+	install -D -m755 chkboot-bootcheck $(LIBEXEC)/chkboot/chkboot-bootcheck
 
 install-initcpio: install
 	install -D -m644 mkinitcpio-hooks/chkboot-initcpio $(LIB)/initcpio/install/chkboot
@@ -22,6 +24,5 @@ install-pacman: install
 
 install-systemd: install
 	install -D -m644 chkboot.service $(LIB)/systemd/system/chkboot.service
-	install -D -m755 chkboot-bootcheck $(LIB)/systemd/scripts/chkboot-bootcheck
 
 .PHONY: all install install-initcpio install-pacman install-systemd

--- a/README.md
+++ b/README.md
@@ -89,12 +89,11 @@ Run `systemctl --system daemon-reload` and then `systemctl enable chkboot`
 
 ### OPTIONAL:
 
-`chkboot-bootcheck` can be installed elsewhere and added to the startup sequence 
-with another system:
+`chkboot-bootcheck` can be added to the startup sequence with another system:
 
 ```
 install -D -m644 chkboot/chkboot.service /usr/lib/systemd/system/chkboot.service
-install -D -m755 chkboot/chkboot-bootcheck /usr/lib/systemd/scripts/chkboot-bootcheck
+install -D -m755 chkboot/chkboot-bootcheck /usr/libexec/chkboot/chkboot-bootcheck
 ```
 
 ``chkboot-desktopalert`` notifies the desktop user about the change and can be

--- a/chkboot
+++ b/chkboot
@@ -25,7 +25,7 @@ if [ "$UID" -ne 0 ]; then
     exit 1
 fi
 
-source /etc/default/chkboot.conf
+source /etc/default/chkboot
 
 CURRTIME=`date +"%Y%m%d-%H%M%S"`
 BOOTFILES="${CHKBOOT_DATA}/BOOTFILES-$CURRTIME"

--- a/chkboot-bootcheck
+++ b/chkboot-bootcheck
@@ -8,7 +8,7 @@
 #
 # license: GPLv2
 
-source /etc/default/chkboot.conf
+source /etc/default/chkboot
 
 chkboot
 

--- a/chkboot-bootcheck
+++ b/chkboot-bootcheck
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# chkboot-bootcheck: on systemd systems, copy this to /usr/lib/systemd/scripts/ and start the chkboot-boot.service
-#                    on other systems, copy this somewhere it can be acceed during boot and add it to the end of the boot process
+# chkboot-bootcheck: copy this to /usr/libexec/chkboot/ and start the chkboot-boot.service
+#                    on other systems, copy this and add it to the end of the boot process
 #
 # author: ju (ju at heisec dot de)
 # contributors: inhies, prurigro

--- a/chkboot-check
+++ b/chkboot-check
@@ -7,7 +7,7 @@
 #
 # license: GPLv2
 
-source /etc/default/chkboot.conf
+source /etc/default/chkboot
 
 if [[ -s "${CHKBOOT_DATA}/${CHANGES_ALERT}" ]]; then
     echo -e -n "\e[0;${HIGHLIGHT_COLOUR};47m"

--- a/chkboot.service
+++ b/chkboot.service
@@ -5,7 +5,7 @@ After=basic.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/lib/systemd/scripts/chkboot-bootcheck
+ExecStart=/usr/libexec/chkboot/chkboot-bootcheck
 
 [Install]
 WantedBy=multi-user.target

--- a/notification/chkboot-desktopalert
+++ b/notification/chkboot-desktopalert
@@ -5,7 +5,7 @@
 #
 # License: GPLv2 or later
 
-source /etc/default/chkboot.conf
+source /etc/default/chkboot
 
 chgfile=${CHKBOOT_DATA}/${CHANGES_ALERT}
 

--- a/notification/chkboot-profilealert.sh
+++ b/notification/chkboot-profilealert.sh
@@ -7,7 +7,7 @@
 #
 # license: GPLv2
 
-source /etc/default/chkboot.conf
+source /etc/default/chkboot
 
 # only try to display chkboot changes if the 'proofile' alert style has been selected
 if [ ! $(echo "${CHKBOOT_STYLES}" | grep -c "profile") = 0 ]; then

--- a/pacman-hooks/80-chkboot-check.hook
+++ b/pacman-hooks/80-chkboot-check.hook
@@ -10,4 +10,4 @@ Depends = chkboot
 Depends = coreutils
 Description = Comparing chkboot hashes...
 When = PreTransaction
-Exec = /usr/bin/sh -c 'if [ -s /var/lib/chkboot/boot-differences ]; then /usr/bin/echo "      ###WARNING### Previously modified boot files not acknowledged"; /usr/bin/echo "      ###WARNING### See chkboot log for details"; fi; /usr/lib/systemd/scripts/chkboot-bootcheck && if [ -s /var/lib/chkboot/boot-differences ]; then /usr/bin/echo "      ###WARNING### Modified boot files detected since last boot"; /usr/bin/echo "      ###WARNING### See chkboot log for details"; fi'
+Exec = /usr/bin/sh -c 'if [ -s /var/lib/chkboot/boot-differences ]; then /usr/bin/echo "      ###WARNING### Previously modified boot files not acknowledged"; /usr/bin/echo "      ###WARNING### See chkboot log for details"; fi; /usr/libexec/chkboot/chkboot-bootcheck && if [ -s /var/lib/chkboot/boot-differences ]; then /usr/bin/echo "      ###WARNING### Modified boot files detected since last boot"; /usr/bin/echo "      ###WARNING### See chkboot log for details"; fi'


### PR DESCRIPTION
This PR installs `chkboot.conf` and `chkboot-bootcheck` to more appropriate path.

- `chkboot.conf`: Removed the `.conf` suffix. Files under /etc/default follow the convention `progname`.
- `chkboot-bootcheck`: Installed under `/usr/libexec/chkboot/` so that it can live in the same place regardless of user's init system.
  The script is now installed by default.