### PR TITLE
License identifier in files wrongly state GPLv2

### DIFF
--- a/chkboot
+++ b/chkboot
@@ -5,7 +5,7 @@
 # author: ju (ju at heisec dot de)
 # contributors: inhies, prurigro
 #
-# license: GPLv2
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # a reminder that this will NOT protect against:
 #   -a trojan hiding in your BIOS

--- a/chkboot-bootcheck
+++ b/chkboot-bootcheck
@@ -6,7 +6,7 @@
 # author: ju (ju at heisec dot de)
 # contributors: inhies, prurigro
 #
-# license: GPLv2
+# SPDX-License-Identifier: GPL-2.0-or-later
 
 source /etc/default/chkboot.conf
 

--- a/chkboot-check
+++ b/chkboot-check
@@ -5,7 +5,7 @@
 # author: ju (ju at heisec dot de)
 # contributors: inhies, prurigro
 #
-# license: GPLv2
+# SPDX-License-Identifier: GPL-2.0-or-later
 
 source /etc/default/chkboot.conf
 

--- a/mkinitcpio-hooks/chkboot-initcpio
+++ b/mkinitcpio-hooks/chkboot-initcpio
@@ -7,7 +7,7 @@
 # author: ju (ju at heisec dot de)
 # contributors: inhies, prurigro
 #
-# license: GPLv2
+# SPDX-License-Identifier: GPL-2.0-or-later
 
 build() {
     echo "Updating chkboot hashes of your boot files..."

--- a/notification/chkboot-desktopalert
+++ b/notification/chkboot-desktopalert
@@ -3,7 +3,7 @@
 # small script to check if files under /boot changed
 # Author: https://github.com/sercxanto
 #
-# License: GPLv2 or later
+# SPDX-License-Identifier: GPL-2.0-or-later
 
 source /etc/default/chkboot.conf
 

--- a/notification/chkboot-profilealert.sh
+++ b/notification/chkboot-profilealert.sh
@@ -5,7 +5,7 @@
 # author: ju (ju at heisec dot de)
 # contributors: inhies, prurigro
 #
-# license: GPLv2
+# SPDX-License-Identifier: GPL-2.0-or-later
 
 source /etc/default/chkboot.conf
 


### PR DESCRIPTION
According to LICENSE.md and commits preceding 3601ba0b68138bfb30295ee113b425f810494b14, files are licensed under the
GPLv2 or later.

This PR fixes license identifier from GPLv2 to GPL-2.0-or-later (using the SPDX standard identifier) as those are different and the later is correct.

